### PR TITLE
Prep 1.2.3

### DIFF
--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["daxpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"

--- a/packages/pyo3/src/lib.rs
+++ b/packages/pyo3/src/lib.rs
@@ -92,7 +92,7 @@ impl HierarchicalCluster {
 /// :raises ParameterRangeError: One of the parameters provided did not meet the requirements in the documentation.
 /// :raises UnsafeInducementError: An internal algorithm error. Please report with reproduction steps.
 #[pyfunction]
-#[pyo3(signature=(edges, /, starting_communities=None, resolution=1.0, randomness=0.001, iterations=1, use_modularity=true, seed=None, trials=1))]
+#[pyo3(signature=(/, edges, starting_communities=None, resolution=1.0, randomness=0.001, iterations=1, use_modularity=true, seed=None, trials=1))]
 fn leiden(
     py: Python,
     edges: Vec<Edge>,
@@ -170,7 +170,7 @@ fn leiden(
 /// :raises ParameterRangeError: One of the parameters provided did not meet the requirements in the documentation.
 /// :raises UnsafeInducementError: An internal algorithm error. Please report with reproduction steps.
 #[pyfunction]
-#[pyo3(signature=(edges, /, starting_communities=None, resolution=1.0, randomness=0.001, iterations=1, use_modularity=true, max_cluster_size=1000, seed=None))]
+#[pyo3(signature=(/, edges, starting_communities=None, resolution=1.0, randomness=0.001, iterations=1, use_modularity=true, max_cluster_size=1000, seed=None))]
 fn hierarchical_leiden(
     py: Python,
     edges: Vec<Edge>,
@@ -211,7 +211,7 @@ fn hierarchical_leiden(
 /// :return: The modularity of the community partitioning provided for the network.
 /// :rtype: float
 #[pyfunction]
-#[pyo3(signature=(edges, communities, /, resolution=1.0))]
+#[pyo3(signature=(/, edges, communities, resolution=1.0))]
 fn modularity(
     py: Python,
     edges: Vec<Edge>,

--- a/packages/pyo3/tests/test_leiden.py
+++ b/packages/pyo3/tests/test_leiden.py
@@ -19,7 +19,7 @@ def _get_edges(path):
 class TestLeiden(unittest.TestCase):
     def test_leiden(self):
         edges = _get_edges(sbm_graph)
-        modularity, partitions = gcn.leiden(edges, seed=seed)
+        modularity, partitions = gcn.leiden(edges=edges, seed=seed)
 
     def test_reiterative_leiden(self):
         """

--- a/packages/pyo3/uv.lock
+++ b/packages/pyo3/uv.lock
@@ -1,5 +1,17 @@
 version = 1
 requires-python = ">=3.8, <3.14"
+resolution-markers = [
+    "python_full_version < '3.10' and sys_platform == 'win32'",
+    "(python_full_version == '3.10.*' and platform_system != 'Windows' and sys_platform == 'win32') or (python_full_version == '3.10.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32')",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.10' and sys_platform != 'win32'",
+    "(python_full_version == '3.10.*' and platform_system != 'Windows' and sys_platform != 'win32') or (python_full_version == '3.10.*' and platform_python_implementation == 'PyPy' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy' and platform_system == 'Windows' and sys_platform == 'win32'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy' and platform_system == 'Windows' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "appnope"
@@ -57,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "graspologic-native"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -145,7 +157,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
 wheels = [


### PR DESCRIPTION
These changes should be the same as the previous signatures provided - though the modularity function had inconsistency between the signature and the pyfunction macro specification in previous versions. This inconsistency is now fixed, but I'm unsure if this is a breaking change or not. Functionally it should not behave any differently, but the documented specification will now appear -- correctly -- to be different than the lies it told before.