### PR TITLE
Prep 1.2.4 fix publication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,10 @@ jobs:
         with:
           name: dist-macos-latest
           path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-ubuntu-24.04-arm
+          path: dist/
       - name: Generate SHA256 files for each wheel
         run: |
           sha256sum dist/*.whl > checksums.txt


### PR DESCRIPTION
We should actually upload the arm wheels - it would be a shame to build them and throw them into the abyss