### PR TITLE
Release 1.2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest", "ubuntu-24.04-arm"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -84,6 +84,16 @@ jobs:
           maturin-version: 1.4.0
           command: build
           target: x64
+          args: -m packages/pyo3/Cargo.toml --release --sdist
+          manylinux: 2014
+
+      - uses: PyO3/maturin-action@v1
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        name: Maturin Build for Linux
+        with:
+          maturin-version: 1.4.0
+          command: build
+          target: aarch64
           args: -m packages/pyo3/Cargo.toml --release --sdist
           manylinux: 2014
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,10 @@ jobs:
         with:
           name: dist-macos-latest
           path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-ubuntu-24.04-arm
+          path: dist/
       - name: Generate SHA256 files for each wheel
         run: |
           sha256sum dist/*.whl > checksums.txt

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["daxpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"
@@ -19,4 +19,3 @@ network_partitions = { path = "../network_partitions" }
 [dependencies.pyo3]
 version = "0.23"
 features = ["extension-module", "abi3-py38"]
-


### PR DESCRIPTION
This PR will release 1.2.4. This build will include new support for aarch64.

@tosone once you confirm the prerelease @ `pip install graspologic-native==1.2.4.dev2025022413506458009` works acceptably, I will merge this PR and finalize this release.