### PR TITLE
fix: add explicit lifetime annotations to silence rust 1.94 warnings

### DIFF
--- a/packages/network_partitions/src/leiden/neighboring_clusters.rs
+++ b/packages/network_partitions/src/leiden/neighboring_clusters.rs
@@ -61,7 +61,7 @@ impl NeighboringClusters {
         self.neighbor_edge_weights_within_cluster[cluster]
     }
 
-    pub fn iter(&self) -> Iter<usize> {
+    pub fn iter(&self) -> Iter<'_, usize> {
         self.neighboring_clusters.iter()
     }
 }

--- a/packages/network_partitions/src/network/compact_network.rs
+++ b/packages/network_partitions/src/network/compact_network.rs
@@ -154,7 +154,7 @@ impl CompactNetwork {
     pub fn node(
         &self,
         id: CompactNodeId,
-    ) -> CompactNodeItem {
+    ) -> CompactNodeItem<'_> {
         let weight: &f64 = &self.nodes[id].0;
         CompactNodeItem {
             id,
@@ -166,7 +166,7 @@ impl CompactNetwork {
     pub fn neighbors_for(
         &self,
         id: CompactNodeId,
-    ) -> NeighborIterator {
+    ) -> NeighborIterator<'_> {
         let neighbor_range: Range<ConnectionId> = self.neighbor_range(id);
         let neighbor_start: ConnectionId = neighbor_range.start;
         NeighborIterator {


### PR DESCRIPTION
the `mismatched_lifetime_syntaxes` lint now warns when elided lifetimes are inconsistent between `&self` and the return type. adds `'_` to three return types in network_partitions.

When I tried to use this as a dependency, rustc gave the following errors:

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> vendor/graspologic-native/packages/network_partitions/src/leiden/neighboring_clusters.rs:64:17
   |
64 |     pub fn iter(&self) -> Iter<usize> {
   |                 ^^^^^     ^^^^^^^^^^^ the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
64 |     pub fn iter(&self) -> Iter<'_, usize> {
   |                                +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> vendor/graspologic-native/packages/network_partitions/src/network/compact_network.rs:155:9
    |
155 |         &self,
    |         ^^^^^ the lifetime is elided here
156 |         id: CompactNodeId,
157 |     ) -> CompactNodeItem {
    |          ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
157 |     ) -> CompactNodeItem<'_> {
    |                         ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> vendor/graspologic-native/packages/network_partitions/src/network/compact_network.rs:167:9
    |
167 |         &self,
    |         ^^^^^ the lifetime is elided here
168 |         id: CompactNodeId,
169 |     ) -> NeighborIterator {
    |          ^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
169 |     ) -> NeighborIterator<'_> {
    |                          ++++

warning: `network_partitions` (lib) generated 3 warnings (run `cargo fix --lib -p network_partitions` to apply 3 suggestions)
```