### PR TITLE
chore: modernize build toolchain and expand platform support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
       - name: Check format
         run: |
           cargo fmt -- --check
+      - name: Clippy
+        run: |
+          cargo clippy --all-targets -- -D warnings
   version:
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,18 +4,18 @@ jobs:
   codestyle-check:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check format
         run: |
           cargo fmt -- --check
   version:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: "3.14"
       - name: Materialize build number
         run: |
           pip install -U pip
@@ -31,17 +31,49 @@ jobs:
           path: version.txt
   build:
     needs: ['codestyle-check', 'version']
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest", "ubuntu-24.04-arm"]
+        include:
+          - runner: ubuntu-latest
+            target: x64
+            manylinux: "2014"
+            args: -m packages/pyo3/Cargo.toml --release --sdist
+            artifact-name: dist-linux-x64
+          - runner: ubuntu-24.04-arm
+            target: aarch64
+            manylinux: "2014"
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-linux-aarch64
+          - runner: ubuntu-latest
+            target: x64
+            manylinux: musllinux_1_2
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-musllinux-x64
+          - runner: ubuntu-24.04-arm
+            target: aarch64
+            manylinux: musllinux_1_2
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-musllinux-aarch64
+          - runner: windows-latest
+            target: x64
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-windows-x64
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-windows-aarch64
+          - runner: macos-latest
+            target: universal2-apple-darwin
+            args: -m packages/pyo3/Cargo.toml --release
+            artifact-name: dist-macos-universal2
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: "3.14"
       - uses: actions/download-artifact@v4
         with:
           name: cargo-toml
@@ -54,50 +86,25 @@ jobs:
         run: |
           cargo test --manifest-path packages/network_partitions/Cargo.toml
 
-      # the following are the actual maturin build actions. each one is different per OS, so rather than copy/paste
-      # the same steps except for the build, we conditionally do one of the builds depending on the os in question
-      # note that windows and mac don't do sdists, but ubuntu does; this is just because we don't need to repeat
-      # ourselves or overwrite the .tar.gz sdist.
+      - uses: PyO3/maturin-action@v1
+        if: ${{ !startsWith(matrix.runner, 'windows') }}
+        name: Maturin Build
+        with:
+          command: build
+          target: ${{ matrix.target }}
+          args: ${{ matrix.args }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
 
       - uses: PyO3/maturin-action@v1
-        if: ${{ matrix.os == 'windows-latest' }}
-        name: Maturin Build for Windows
+        if: ${{ startsWith(matrix.runner, 'windows') }}
+        name: Maturin Build (Windows)
         with:
-          maturin-version: 1.4.0
           command: build
-          target: x64
-          args: -m packages/pyo3/Cargo.toml --release -i ${{env.pythonLocation}}\python.exe
-
-      - uses: PyO3/maturin-action@v1
-        if: ${{ matrix.os == 'macos-latest' }}
-        name: Maturin Build for MacOS
-        with:
-          maturin-version: 1.4.0
-          command: build
-          target: universal2-apple-darwin
-          args: -m packages/pyo3/Cargo.toml --release
-
-      - uses: PyO3/maturin-action@v1
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: Maturin Build for Linux
-        with:
-          maturin-version: 1.4.0
-          command: build
-          target: x64
-          args: -m packages/pyo3/Cargo.toml --release --sdist
-          manylinux: 2014
-
-      - uses: PyO3/maturin-action@v1
-        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
-        name: Maturin Build for Linux
-        with:
-          maturin-version: 1.4.0
-          command: build
-          target: aarch64
-          args: -m packages/pyo3/Cargo.toml --release --sdist
-          manylinux: 2014
+          target: ${{ matrix.target }}
+          args: ${{ matrix.args }} -i ${{env.pythonLocation}}\python.exe
 
       - name: Python Unittests
+        if: ${{ !matrix.manylinux || matrix.manylinux != 'musllinux_1_2' }}
         run: |
           cd packages/pyo3
           pip install ../../target/wheels/*.whl
@@ -106,7 +113,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}
+          name: ${{ matrix.artifact-name }}
           path: |
             target/wheels/*.whl
             target/wheels/*.tar.gz
@@ -114,27 +121,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: 'build'
     if: github.ref=='refs/heads/main' || github.ref=='refs/heads/dev'
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: "3.14"
       - uses: actions/download-artifact@v4
         with:
-          name: dist-ubuntu-latest
+          name: dist-linux-x64
           path: dist/
       - uses: actions/download-artifact@v4
         with:
-          name: dist-windows-latest
+          name: dist-linux-aarch64
           path: dist/
       - uses: actions/download-artifact@v4
         with:
-          name: dist-macos-latest
+          name: dist-musllinux-x64
           path: dist/
       - uses: actions/download-artifact@v4
         with:
-          name: dist-ubuntu-24.04-arm
+          name: dist-musllinux-aarch64
+          path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-windows-x64
+          path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-windows-aarch64
+          path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-macos-universal2
           path: dist/
       - name: Generate SHA256 files for each wheel
         run: |
@@ -160,12 +181,17 @@ jobs:
         run: |
           twine upload dist/*
       - name: Create Github Release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.GRASPOLOGIC_VERSION }}
-          release_name: graspologic-native-${{ env.GRASPOLOGIC_VERSION }}
-          body_path: "checksums.txt"
-          prerelease: github.ref=='refs/heads/dev'
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$GRASPOLOGIC_VERSION" \
+            --title "graspologic-native-${GRASPOLOGIC_VERSION}" \
+            --notes-file checksums.txt \
+            $PRERELEASE_FLAG \
+            dist/*.whl \
+            dist/*.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,34 +43,34 @@ jobs:
             target: x64
             manylinux: "2014"
             args: -m packages/pyo3/Cargo.toml --release --sdist
-            artifact-name: dist-linux-x64
+            artifact_name: dist-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: "2014"
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-linux-aarch64
+            artifact_name: dist-linux-aarch64
           - runner: ubuntu-latest
             target: x64
             manylinux: musllinux_1_2
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-musllinux-x64
+            artifact_name: dist-musllinux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: musllinux_1_2
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-musllinux-aarch64
+            artifact_name: dist-musllinux-aarch64
           - runner: windows-latest
             target: x64
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-windows-x64
+            artifact_name: dist-windows-x64
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-windows-aarch64
+            artifact_name: dist-windows-aarch64
           - runner: macos-latest
             target: universal2-apple-darwin
             args: -m packages/pyo3/Cargo.toml --release
-            artifact-name: dist-macos-universal2
+            artifact_name: dist-macos-universal2
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact_name }}
           path: |
             target/wheels/*.whl
             target/wheels/*.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["packages/network_partitions", "packages/cli", "packages/pyo3"]
+resolver = "3"
 
 [profile.release]
 opt-level = 3

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "cli"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Dax Pryce <daxpryce@microsoft.com>"]
-edition = "2018"
+edition = "2024"
 license = "MIT"
 description = "CLI Runner for the topologic associated crates (network_partitions and eventually network_automatic_layouts)"
 
 [dependencies]
-clap = "4.5"
-rand = "0.8"
-rand_xorshift = "0.3"
+clap = "4"
+rand = "0.10"
 network_partitions={path = "../network_partitions"}

--- a/packages/cli/src/leiden.rs
+++ b/packages/cli/src/leiden.rs
@@ -8,7 +8,7 @@ use network_partitions::network::prelude::*;
 use network_partitions::quality;
 
 use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use rand::rngs::SmallRng;
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -44,12 +44,12 @@ pub fn leiden(
 
     let loaded_file_instant: Instant = Instant::now();
 
-    let mut rng: XorShiftRng = match seed {
+    let mut rng: SmallRng = match seed {
         Some(seed) => {
             println!("Using {} for PRNG seed", seed as u64);
-            XorShiftRng::seed_from_u64(seed as u64)
+            SmallRng::seed_from_u64(seed as u64)
         }
-        None => XorShiftRng::from_entropy(),
+        None => SmallRng::from_rng(&mut rand::rng()),
     };
 
     let result: Result<(bool, Clustering), CoreError> = leiden_internal(

--- a/packages/network_partitions/Cargo.toml
+++ b/packages/network_partitions/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "network_partitions"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dax Pryce <daxpryce@microsoft.com>"]
-edition = "2018"
+edition = "2024"
 license = "MIT"
 description = "Leiden community detection as per https://arxiv.org/abs/1810.08473"
 
 [dependencies]
-rand = "0.8"
-
-[dev-dependencies]
-rand_xorshift = "0.3"
-
+rand = "0.10"

--- a/packages/network_partitions/src/leiden/full_network_clustering.rs
+++ b/packages/network_partitions/src/leiden/full_network_clustering.rs
@@ -257,11 +257,11 @@ mod tests {
     use crate::network::{Edge, LabeledNetwork};
     use crate::resolution;
     use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
+    use rand::rngs::SmallRng;
 
     #[test]
     fn test_improve_initial_clustering() {
-        let mut rng: XorShiftRng = XorShiftRng::seed_from_u64(1234);
+        let mut rng: SmallRng = SmallRng::seed_from_u64(1234);
 
         // generate same graph as in java, done via Network object not InternalNetwork, then
         // generate a InternalNetwork from it

--- a/packages/network_partitions/src/leiden/full_network_work_queue.rs
+++ b/packages/network_partitions/src/leiden/full_network_work_queue.rs
@@ -4,7 +4,7 @@
 use crate::errors::CoreError;
 use std::collections::VecDeque;
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 /// The FullNetworkWorkQueue is a composite class of a circular work queue and a vec of bools indicating
 /// when a node should be treated as stable
@@ -62,7 +62,7 @@ impl FullNetworkWorkQueue {
         let mut stable: Vec<bool> = Vec::with_capacity(len);
         for i in 0..len {
             stable.push(false);
-            let random_index: usize = rng.gen_range(0..len);
+            let random_index: usize = rng.random_range(0..len);
             permutation.swap(i, random_index);
         }
         let work_queue: VecDeque<usize> = VecDeque::from(permutation);
@@ -110,12 +110,12 @@ impl FullNetworkWorkQueue {
 mod tests {
     use super::*;
     use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
+    use rand::rngs::SmallRng;
 
     #[test]
     fn test_determinism() {
-        let mut rng1: XorShiftRng = XorShiftRng::seed_from_u64(1234);
-        let mut rng2: XorShiftRng = XorShiftRng::seed_from_u64(1234);
+        let mut rng1: SmallRng = SmallRng::seed_from_u64(1234);
+        let mut rng2: SmallRng = SmallRng::seed_from_u64(1234);
         let order_1: FullNetworkWorkQueue =
             FullNetworkWorkQueue::items_in_random_order(100000, &mut rng1);
         let order_2: FullNetworkWorkQueue =

--- a/packages/network_partitions/src/leiden/leiden_clustering.rs
+++ b/packages/network_partitions/src/leiden/leiden_clustering.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 use std::collections::{HashMap, HashSet};
-use std::iter;
 
 use rand::Rng;
 
@@ -198,8 +197,10 @@ fn initial_clustering_for_induced(
         num_nodes_per_cluster_induced_network.iter().enumerate()
     {
         // fill num_nodes_per_induced_cluster_index into positions from clusters_induced_network_index to clusters_induced_network_index + num_nodes_per_cluster_reduced_network[num_nodes_per_induced_cluster_index]
-        clusters_induced_network
-            .extend(iter::repeat(num_nodes_per_induced_cluster_index).take(*repetitions));
+        clusters_induced_network.extend(std::iter::repeat_n(
+            num_nodes_per_induced_cluster_index,
+            *repetitions,
+        ));
     }
     let next_cluster_id: usize = match clusters_induced_network.last() {
         Some(largest_cluster) => *largest_cluster + 1,
@@ -274,7 +275,7 @@ mod tests {
             ("g".into(), "c".into(), 3.0),
             ("h".into(), "d".into(), 11.0),
         ];
-        return edges;
+        edges
     }
 
     #[test]
@@ -308,7 +309,7 @@ mod tests {
             .expect("Updating this known cluster for h should work");
         clustering.remove_empty_clusters();
         assert_eq!(clustering[a_compact], clustering[h_compact]);
-        guarantee_clustering_sanity(&compact_network, &mut clustering)
+        guarantee_clustering_sanity(compact_network, &mut clustering)
             .expect("guarantee clustering sanity should not throw an error");
         assert_ne!(clustering[a_compact], clustering[h_compact]);
         let isolate_clusters: Vec<ClusterId> = vec![clustering[a_compact], clustering[h_compact]];

--- a/packages/network_partitions/src/leiden/mod.rs
+++ b/packages/network_partitions/src/leiden/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-pub use self::hierarchical::{hierarchical_leiden, HierarchicalCluster};
+pub use self::hierarchical::{HierarchicalCluster, hierarchical_leiden};
 pub use self::leiden_clustering::leiden;
 
 mod full_network_clustering;

--- a/packages/network_partitions/src/leiden/neighboring_clusters.rs
+++ b/packages/network_partitions/src/leiden/neighboring_clusters.rs
@@ -47,10 +47,10 @@ impl NeighboringClusters {
 
     pub fn freeze(&mut self) {
         // only set the weight for the current cluster if no other neighbors belong to it.
-        if let Some(current_cluster) = self.current_cluster {
-            if self.neighbor_edge_weights_within_cluster[current_cluster].is_nan() {
-                self.neighbor_edge_weights_within_cluster[current_cluster] = 0_f64;
-            }
+        if let Some(current_cluster) = self.current_cluster
+            && self.neighbor_edge_weights_within_cluster[current_cluster].is_nan()
+        {
+            self.neighbor_edge_weights_within_cluster[current_cluster] = 0_f64;
         }
     }
 

--- a/packages/network_partitions/src/leiden/subnetwork.rs
+++ b/packages/network_partitions/src/leiden/subnetwork.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::quality_value_increment::calculate;
 use crate::clustering::Clustering;
@@ -162,7 +162,7 @@ impl SubnetworkClusteringGenerator {
         }
 
         for i in 0..length {
-            let random_index: usize = rng.gen_range(0..length);
+            let random_index: usize = rng.random_range(0..length);
             self.node_processing_order.swap(i, random_index);
         }
     }
@@ -244,7 +244,7 @@ where
     }
 
     let chosen_cluster: usize = if total_adjusted_qvi.is_finite() {
-        let randomized_transform_qv: f64 = total_adjusted_qvi * rng.gen::<f64>(); // rng.gen will return a number [0.0, 1.0)
+        let randomized_transform_qv: f64 = total_adjusted_qvi * rng.random::<f64>(); // rng.random will return a number [0.0, 1.0)
         let bin_search_result: Result<usize, usize> = summed_qvi_records
             .binary_search_by(|probe: &f64| probe.partial_cmp(&randomized_transform_qv).unwrap());
         let location: usize = match bin_search_result {

--- a/packages/network_partitions/src/network/compact_network.rs
+++ b/packages/network_partitions/src/network/compact_network.rs
@@ -148,7 +148,7 @@ impl CompactNetwork {
         } else {
             self.neighbors.len()
         };
-        return neighbor_start..end_range;
+        neighbor_start..end_range
     }
 
     pub fn node(
@@ -226,7 +226,8 @@ impl CompactNetwork {
     ) -> impl Iterator<Item = CompactSubnetworkItem<CompactNodeId>> + 'a {
         let mut labeled_network_builder: LabeledNetworkBuilder<CompactNodeId> =
             LabeledNetworkBuilder::new();
-        let subnetwork_iterator = nodes_by_cluster
+
+        nodes_by_cluster
             .iter()
             .enumerate()
             .filter(move |(_cluster_id, nodes_in_cluster)| {
@@ -244,8 +245,7 @@ impl CompactNetwork {
                     subnetwork,
                     id: cluster_id,
                 }
-            });
-        subnetwork_iterator
+            })
     }
 
     pub fn induce_clustering_network(
@@ -421,11 +421,7 @@ impl Iterator for SubnetworkIterator<'_, '_> {
                         possibly_valid += 1;
                     }
                 }
-                if found {
-                    Some(possibly_valid)
-                } else {
-                    None
-                }
+                if found { Some(possibly_valid) } else { None }
             }
         };
         match next_valid_position {
@@ -525,7 +521,7 @@ pub mod tests {
             (2, 3_f64),
             (3, 11_f64), // 7
         ];
-        return CompactNetwork::from(nodes, neighbors, self_links);
+        CompactNetwork::from(nodes, neighbors, self_links)
     }
 
     #[test]

--- a/packages/network_partitions/src/network/labeled_network.rs
+++ b/packages/network_partitions/src/network/labeled_network.rs
@@ -270,7 +270,7 @@ pub mod tests {
             ("g".into(), "c".into(), 3.0),
             ("h".into(), "d".into(), 11.0),
         ];
-        return edges;
+        edges
     }
 
     fn expected_label_mappings() -> (HashMap<String, usize>, Vec<String>) {
@@ -290,8 +290,8 @@ pub mod tests {
             .enumerate()
             .map(|(index, label)| (label, index))
             .collect();
-        let label_to_id: HashMap<String, usize> = HashMap::from_iter(label_to_id_vec.into_iter());
-        return (label_to_id, label_order);
+        let label_to_id: HashMap<String, usize> = HashMap::from_iter(label_to_id_vec);
+        (label_to_id, label_order)
     }
 
     #[test]

--- a/packages/network_partitions/src/network/prelude.rs
+++ b/packages/network_partitions/src/network/prelude.rs
@@ -1,6 +1,6 @@
+pub use super::Edge;
 pub use super::compact_network::{
     ClusterId, CompactNetwork, CompactNodeId, CompactNodeItem, CompactSubnetworkItem,
 };
 pub use super::labeled_network::{LabeledNetwork, LabeledNetworkBuilder};
 pub use super::networks::NetworkDetails;
-pub use super::Edge;

--- a/packages/network_partitions/src/random_vector.rs
+++ b/packages/network_partitions/src/random_vector.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 /// Generates a Vec of length `length`, initially populated with values from 0..length.
 /// Executes `length` number of swaps based on current position and an index chosen at random
@@ -18,7 +18,7 @@ where
     }
 
     for i in 0..length {
-        let random_index: usize = rng.gen_range(0..length);
+        let random_index: usize = rng.random_range(0..length);
         permutation.swap(i, random_index);
     }
 

--- a/packages/network_partitions/tests/test_network.rs
+++ b/packages/network_partitions/tests/test_network.rs
@@ -27,16 +27,12 @@ mod tests {
             );
         assert!(result.is_err());
         match result.err() {
-            Some(NetworkError::EdgeFileFormatError) => assert!(true),
-            Some(err) => assert!(
-                false,
+            Some(NetworkError::EdgeFileFormatError) => {}
+            Some(err) => panic!(
                 "Actual NetworkError returned was not EdgeFileFormatError but an {:?}",
                 err
             ),
-            _ => assert!(
-                false,
-                "Somehow this file was parsed correctly, which is certainly wrong"
-            ),
+            _ => panic!("Somehow this file was parsed correctly, which is certainly wrong"),
         }
     }
 }

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "graspologic_native"
-version = "1.2.5"
+version = "1.3.0"
 authors = ["daxpryce@microsoft.com"]
-edition = "2018"
+edition = "2024"
 license = "MIT"
 description = "Python native companion module to the graspologic library"
 readme = "README.md"
@@ -12,10 +12,9 @@ name = "graspologic_native"
 crate-type = ["rlib","cdylib"]
 
 [dependencies]
-rand = "0.8"
-rand_xorshift = "0.3"
+rand = "0.10"
 network_partitions = { path = "../network_partitions" }
 
 [dependencies.pyo3]
-version = "0.24.1"
-features = ["extension-module", "abi3-py38"]
+version = "0.28"
+features = ["extension-module", "abi3-py39"]

--- a/packages/pyo3/pyproject.toml
+++ b/packages/pyo3/pyproject.toml
@@ -7,12 +7,11 @@ maintainers = [
     {name = "Dax Pryce", email = "daxpryce@microsoft.com"}
 ]
 dynamic = ["version"]
-requires-python = ">=3.8,<3.14"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ Github = "https://github.com/graspologic-org/graspologic-native"
 Graspologic = "https://github.com/graspologic-org/graspologic"
 
 [build-system]
-requires = ["maturin>=1.4,<2.0"]
+requires = ["maturin>=1.13,<2.0"]
 build-backend = "maturin"
 
 [tool.uv]

--- a/packages/pyo3/src/lib.rs
+++ b/packages/pyo3/src/lib.rs
@@ -8,8 +8,8 @@ mod mediator;
 
 use std::collections::{HashMap, HashSet};
 
-use pyo3::prelude::*;
 use pyo3::PyTypeInfo;
+use pyo3::prelude::*;
 
 use network_partitions::clustering::Clustering;
 use network_partitions::errors::CoreError;
@@ -43,11 +43,7 @@ impl HierarchicalCluster {
             .unwrap_or("None".into());
         Ok(format!(
             "HierarchicalCluster(node=\"{}\", cluster=\"{}\", level={}, parent_cluster={}, is_final_cluster={})",
-            self.node,
-            self.cluster,
-            self.level,
-            parent,
-            self.is_final_cluster,
+            self.node, self.cluster, self.level, parent, self.is_final_cluster,
         ))
     }
 
@@ -105,19 +101,18 @@ fn leiden(
     seed: Option<u64>,
     trials: u64,
 ) -> PyResult<(f64, HashMap<String, usize>)> {
-    let result: Result<(f64, HashMap<String, usize>), PyLeidenError> =
-        py.detach(move || {
-            mediator::leiden(
-                edges,
-                starting_communities,
-                resolution,
-                randomness,
-                iterations,
-                use_modularity,
-                seed,
-                trials,
-            )
-        });
+    let result: Result<(f64, HashMap<String, usize>), PyLeidenError> = py.detach(move || {
+        mediator::leiden(
+            edges,
+            starting_communities,
+            resolution,
+            randomness,
+            iterations,
+            use_modularity,
+            seed,
+            trials,
+        )
+    });
     result.map_err(PyErr::from)
 }
 

--- a/packages/pyo3/src/lib.rs
+++ b/packages/pyo3/src/lib.rs
@@ -9,6 +9,7 @@ mod mediator;
 use std::collections::{HashMap, HashSet};
 
 use pyo3::prelude::*;
+use pyo3::PyTypeInfo;
 
 use network_partitions::clustering::Clustering;
 use network_partitions::errors::CoreError;
@@ -105,7 +106,7 @@ fn leiden(
     trials: u64,
 ) -> PyResult<(f64, HashMap<String, usize>)> {
     let result: Result<(f64, HashMap<String, usize>), PyLeidenError> =
-        py.allow_threads(move || {
+        py.detach(move || {
             mediator::leiden(
                 edges,
                 starting_communities,
@@ -182,7 +183,7 @@ fn hierarchical_leiden(
     max_cluster_size: u32,
     seed: Option<u64>,
 ) -> PyResult<Vec<HierarchicalCluster>> {
-    let result: Result<Vec<HierarchicalCluster>, PyLeidenError> = py.allow_threads(move || {
+    let result: Result<Vec<HierarchicalCluster>, PyLeidenError> = py.detach(move || {
         mediator::hierarchical_leiden(
             edges,
             starting_communities,
@@ -219,7 +220,7 @@ fn modularity(
     resolution: f64,
 ) -> PyResult<f64> {
     let result: Result<f64, PyLeidenError> =
-        py.allow_threads(move || mediator::modularity(edges, communities, resolution));
+        py.detach(move || mediator::modularity(edges, communities, resolution));
 
     result.map_err(PyErr::from)
 }
@@ -238,22 +239,22 @@ fn graspologic_native(
 
     module.add(
         "ClusterIndexingError",
-        py.get_type::<ClusterIndexingError>(),
+        ClusterIndexingError::type_object(py),
     )?;
-    module.add("EmptyNetworkError", py.get_type::<EmptyNetworkError>())?;
+    module.add("EmptyNetworkError", EmptyNetworkError::type_object(py))?;
     module.add(
         "InvalidCommunityMappingError",
-        py.get_type::<InvalidCommunityMappingError>(),
+        InvalidCommunityMappingError::type_object(py),
     )?;
     module.add(
         "InternalNetworkIndexingError",
-        py.get_type::<InternalNetworkIndexingError>(),
+        InternalNetworkIndexingError::type_object(py),
     )?;
-    module.add("ParameterRangeError", py.get_type::<ParameterRangeError>())?;
+    module.add("ParameterRangeError", ParameterRangeError::type_object(py))?;
     module.add(
         "UnsafeInducementError",
-        py.get_type::<UnsafeInducementError>(),
+        UnsafeInducementError::type_object(py),
     )?;
-    module.add("QueueError", py.get_type::<QueueError>())?;
+    module.add("QueueError", QueueError::type_object(py))?;
     Ok(())
 }

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -10,11 +10,11 @@ use network_partitions::network::prelude::*;
 use network_partitions::quality;
 use network_partitions::safe_vectors::SafeVectors;
 
-use super::errors::PyLeidenError;
 use super::HierarchicalCluster;
+use super::errors::PyLeidenError;
 use crate::errors::InvalidCommunityMappingError;
-use rand::{Rng, RngExt, SeedableRng};
 use rand::rngs::SmallRng;
+use rand::{Rng, RngExt, SeedableRng};
 
 pub fn leiden(
     edges: Vec<Edge>,
@@ -179,8 +179,7 @@ fn communities_to_clustering(
 
     for (node, community) in communities {
         let mapping: Option<CompactNodeId> = network.compact_id_for(node);
-        if mapping.is_some() {
-            let compact_node_id: CompactNodeId = mapping.unwrap();
+        if let Some(compact_node_id) = mapping {
             clustering
                 .update_cluster_at(compact_node_id, community)
                 .map_err(|_| PyLeidenError::ClusterIndexingError)?;

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -13,8 +13,8 @@ use network_partitions::safe_vectors::SafeVectors;
 use super::errors::PyLeidenError;
 use super::HierarchicalCluster;
 use crate::errors::InvalidCommunityMappingError;
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::{Rng, RngExt, SeedableRng};
+use rand::rngs::SmallRng;
 
 pub fn leiden(
     edges: Vec<Edge>,
@@ -37,9 +37,9 @@ pub fn leiden(
         None => None,
     };
 
-    let mut rng: XorShiftRng = match seed {
-        Some(seed) => XorShiftRng::seed_from_u64(seed),
-        None => XorShiftRng::from_entropy(),
+    let mut rng: SmallRng = match seed {
+        Some(seed) => SmallRng::seed_from_u64(seed),
+        None => SmallRng::from_rng(&mut rand::rng()),
     };
 
     let compact_network: &CompactNetwork = labeled_network.compact();
@@ -111,9 +111,9 @@ pub fn hierarchical_leiden(
         )?),
         None => None,
     };
-    let mut rng: XorShiftRng = match seed {
-        Some(seed) => XorShiftRng::seed_from_u64(seed),
-        None => XorShiftRng::from_entropy(),
+    let mut rng: SmallRng = match seed {
+        Some(seed) => SmallRng::seed_from_u64(seed),
+        None => SmallRng::from_rng(&mut rand::rng()),
     };
 
     let compact_network: &CompactNetwork = labeled_network.compact();


### PR DESCRIPTION
This PR modernizes our build toolchain and expands platform support. 

Notably, it adds windows arm64/aarch64 support.

Seedable RNG remains supported — identical inputs with the same seed will still produce deterministic results within a given version. However, the underlying RNG implementation has changed (XorShift -> Xoshiro256++), so results from a seeded run on v1.3+ will differ from those on earlier versions.