### PR TITLE
ci: update actions and fix ARM manylinux container usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: "2014"
-            container: "2014"
+            container: "quay.io/pypa/manylinux2014_aarch64"
             args: -m packages/pyo3/Cargo.toml --release
             artifact_name: dist-linux-aarch64
           - runner: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: musllinux_1_2
-            container: musllinux_1_2
+            container: "quay.io/pypa/musllinux_1_2_aarch64"
             args: -m packages/pyo3/Cargo.toml --release
             artifact_name: dist-musllinux-aarch64
           - runner: windows-latest
@@ -54,7 +54,7 @@ jobs:
             artifact_name: dist-macos-universal2
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - name: Rust Unittests
         run: |
           cargo test --manifest-path packages/network_partitions/Cargo.toml
@@ -86,7 +86,19 @@ jobs:
           uv run python -m unittest
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - name: Remove non-manylinux Linux wheels
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+        run: |
+          find target/wheels -name '*-linux_*.whl' -delete
+        shell: bash
+
+      - name: Remove non-universal2 macOS wheels
+        if: ${{ startsWith(matrix.runner, 'macos') && contains(matrix.target, 'universal2') }}
+        run: |
+          find target/wheels -name '*.whl' ! -name '*universal2*' -delete
+        shell: bash
+
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: "2014"
-            container: "2014"
+            container: "quay.io/pypa/manylinux2014_aarch64"
             args: -m packages/pyo3/Cargo.toml --release
             artifact_name: dist-linux-aarch64
           - runner: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: musllinux_1_2
-            container: musllinux_1_2
+            container: "quay.io/pypa/musllinux_1_2_aarch64"
             args: -m packages/pyo3/Cargo.toml --release
             artifact_name: dist-musllinux-aarch64
           - runner: windows-latest
@@ -74,7 +74,7 @@ jobs:
             artifact_name: dist-macos-universal2
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
 
       - name: Rust Unittests
         run: |
@@ -107,7 +107,19 @@ jobs:
           uv run python -m unittest
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - name: Remove non-manylinux Linux wheels
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+        run: |
+          find target/wheels -name '*-linux_*.whl' -delete
+        shell: bash
+
+      - name: Remove non-universal2 macOS wheels
+        if: ${{ startsWith(matrix.runner, 'macos') && contains(matrix.target, 'universal2') }}
+        run: |
+          find target/wheels -name '*.whl' ! -name '*universal2*' -delete
+        shell: bash
+
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -123,7 +135,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           merge-multiple: true


### PR DESCRIPTION
Action version bumps (Node.js 24 compatibility):
- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v8
- astral-sh/setup-uv v6 → v7

Fix ARM Linux wheel platform tags:
- The default maturin-action containers for aarch64 are cross-compilation images (ghcr.io/rust-cross/*-cross:aarch64) intended for x86_64 hosts. On native ARM runners (ubuntu-24.04-arm), the action detects matching architecture and skips the container, building natively — which produces 'linux_aarch64' tags that PyPI rejects.
- Fix: explicitly set container to native aarch64 images:
  - manylinux: quay.io/pypa/manylinux2014_aarch64
  - musllinux: quay.io/pypa/musllinux_1_2_aarch64
- Add safety-net filter steps to remove any stray linux_* or non-universal2 wheels before artifact upload.